### PR TITLE
Add argument to run with autofix

### DIFF
--- a/pre_commit_hooks/check_rubocop.py
+++ b/pre_commit_hooks/check_rubocop.py
@@ -7,12 +7,16 @@ import sys
 
 def check_rubocop(argv=None):
     parser = argparse.ArgumentParser()
+    parser.add_argument('-a', help='auto fix', action='store_true')
     parser.add_argument('filenames', nargs='*', help='filenames to check.')
     args = parser.parse_args(argv)
 
     retval = 0
 
     command = ["rubocop", "--force-exclusion", "--display-cop-names"] + args.filenames
+
+    if args.a == True:
+        command += ["-a"]
 
     try:
         retval = subprocess.check_call(command, shell=False)


### PR DESCRIPTION
pre-commit supports code analyser that fixes code, it could be helpful to avoid running rubocop twice.
So I've just added '-a ' (auto fix) option of rubocop to check-rubocop (I'm not so good in python so please review my code !).
